### PR TITLE
[BUGS-9] Forecast area shaded polygon does not displaty

### DIFF
--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/data/model/gridpoint/GridpointResponse.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/data/model/gridpoint/GridpointResponse.kt
@@ -1,7 +1,10 @@
 package com.mattjamesdev.weatherdotgov.data.model.gridpoint
 
 
+import com.google.android.gms.maps.model.LatLng
 import com.google.gson.annotations.SerializedName
+import com.mattjamesdev.weatherdotgov.domain.model.GridpointData
+import com.mattjamesdev.weatherdotgov.domain.model.LatLong
 
 data class GridpointResponse(
     @SerializedName("geometry")
@@ -9,3 +12,22 @@ data class GridpointResponse(
     @SerializedName("id")
     val id: String?,
 )
+
+fun GridpointResponse.toDomain(): GridpointData {
+    this.geometry?.let { geometry ->
+        geometry.coordinates?.let { coordinates ->
+            val points = coordinates.mapIndexedNotNull { index, list ->
+                list?.let {
+                    it.get(0)?.let {
+                        LatLong(it.get(1) ?: 0.0, it.get(0) ?: 0.0)
+                    } ?: LatLong.EMPTY
+                }
+            }
+            return GridpointData(
+                points = points
+            )
+        }
+    }
+
+    return GridpointData.NULL
+}

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/data/model/gridpoint/GridpointResponse.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/data/model/gridpoint/GridpointResponse.kt
@@ -1,7 +1,6 @@
 package com.mattjamesdev.weatherdotgov.data.model.gridpoint
 
 
-import com.google.android.gms.maps.model.LatLng
 import com.google.gson.annotations.SerializedName
 import com.mattjamesdev.weatherdotgov.domain.model.GridpointData
 import com.mattjamesdev.weatherdotgov.domain.model.LatLong
@@ -16,16 +15,17 @@ data class GridpointResponse(
 fun GridpointResponse.toDomain(): GridpointData {
     this.geometry?.let { geometry ->
         geometry.coordinates?.let { coordinates ->
-            val points = coordinates.mapIndexedNotNull { index, list ->
-                list?.let {
-                    it.get(0)?.let {
+            coordinates.get(0)?.let { list ->
+                val points = list.mapIndexedNotNull { index, list2 ->
+                    list2?.let {
                         LatLong(it.get(1) ?: 0.0, it.get(0) ?: 0.0)
-                    } ?: LatLong.EMPTY
+                    }
                 }
+
+                return GridpointData(
+                    points = points
+                )
             }
-            return GridpointData(
-                points = points
-            )
         }
     }
 

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/domain/model/GridpointData.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/domain/model/GridpointData.kt
@@ -1,0 +1,11 @@
+package com.mattjamesdev.weatherdotgov.domain.model
+
+data class GridpointData(
+    val points: List<LatLong>
+) {
+    companion object {
+        val NULL = GridpointData(
+            points = listOf(LatLong.EMPTY)
+        )
+    }
+}

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/domain/model/LatLong.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/domain/model/LatLong.kt
@@ -1,5 +1,7 @@
 package com.mattjamesdev.weatherdotgov.domain.model
 
+import com.google.android.gms.maps.model.LatLng
+
 data class LatLong(
     val lat: Double,
     val long: Double,
@@ -9,7 +11,7 @@ data class LatLong(
 
     override fun toString(): String = "$lat,$long"
 
-    fun toPointForecast(): String = "${lat}°N ${long*-1}°W"
+    fun toPointForecast(): String = "${lat}°N ${long * -1}°W"
 
     companion object {
         val EMPTY = LatLong(
@@ -18,3 +20,10 @@ data class LatLong(
         )
     }
 }
+
+fun LatLong.toLatLng(): LatLng = LatLng(
+    this.lat,
+    this.long
+)
+
+fun List<LatLong>.toLatLngList(): List<LatLng> = this.map { it.toLatLng() }

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/network/WeatherDotGovAPI.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/network/WeatherDotGovAPI.kt
@@ -29,7 +29,7 @@ interface WeatherDotGovAPI {
         @Path("wfo") wfo: String,
         @Path("x") x: Int,
         @Path("y") y: Int
-    ): GridpointResponse
+    ): Response<GridpointResponse>
 
     @GET("gridpoints/{wfo}/{x},{y}/forecast/hourly")
     suspend fun getHourlyForecastData(

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/view/MapFragment.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/view/MapFragment.kt
@@ -99,7 +99,7 @@ class MapFragment : Fragment(), GoogleMap.OnMapClickListener {
             lat = p0.latitude,
             long = p0.longitude
         )
-        viewModel.fetchForecastAreaV2(latLong)
+        viewModel.setLocation(latLong)
     }
 
 

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/view/MapFragment.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/view/MapFragment.kt
@@ -1,8 +1,6 @@
 package com.mattjamesdev.weatherdotgov.view
 
 import android.content.Context
-import androidx.fragment.app.Fragment
-
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -10,9 +8,9 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.gms.maps.CameraUpdateFactory
-
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
@@ -21,6 +19,8 @@ import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.PolygonOptions
 import com.mattjamesdev.weatherdotgov.R
 import com.mattjamesdev.weatherdotgov.domain.model.LatLong
+import com.mattjamesdev.weatherdotgov.domain.model.toLatLng
+import com.mattjamesdev.weatherdotgov.domain.model.toLatLngList
 import com.mattjamesdev.weatherdotgov.viewmodel.SearchActivityViewModel
 
 class MapFragment : Fragment(), GoogleMap.OnMapClickListener {
@@ -30,39 +30,26 @@ class MapFragment : Fragment(), GoogleMap.OnMapClickListener {
 
     private val callback = OnMapReadyCallback { googleMap ->
         viewModel.gridpointData.observe(this) {
+            val points = it.points
+            Log.d(TAG, "New polygon gridpoints: $points")
+
             googleMap.clear()
 
-            // Maps array of array of coordinates to List<LatLng>
-            val polygonPoints =
-                it?.geometry?.coordinates?.mapIndexed { index, list ->
-                    list?.let {
-                        it.get(0)?.let {
-                            LatLng(it.get(1)!!, it.get(0)!!)
-                        }
-                    }
-                }
-            Log.d(TAG, "Polygon points: $polygonPoints")
-
             // Draw polygon from coordinates list
-            polygonPoints?.let {
-                googleMap.addPolygon(
-                    PolygonOptions()
-                        .addAll(it)
-                        .strokeWidth(3f)
-                        .strokeColor(resources.getColor(R.color.polyExterior, context?.theme))
-                        .fillColor(resources.getColor(R.color.polyInterior, context?.theme))
-                )
-            }
+            googleMap.addPolygon(
+                PolygonOptions()
+                    .addAll(points.toLatLngList())
+                    .strokeWidth(3f)
+                    .strokeColor(resources.getColor(R.color.polyExterior, context?.theme))
+                    .fillColor(resources.getColor(R.color.polyInterior, context?.theme))
+            )
 
             // Use coordinates list to build a boundary for the map to locate and focus on
             val boundsBuilder = LatLngBounds.Builder()
-            polygonPoints?.let {
-                for (point in it) {
-                    point?.let {
-                        boundsBuilder.include(it)
-                    }
-                }
+            for (point in points) {
+                boundsBuilder.include(point.toLatLng())
             }
+
             val bounds = boundsBuilder.build()
 
             googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(bounds.center, 12f))
@@ -86,8 +73,17 @@ class MapFragment : Fragment(), GoogleMap.OnMapClickListener {
 
         // Assists in giving high scroll/touch precedence to Map Fragment
         val frameLayout = TouchableWrapper(requireActivity())
-        frameLayout.setBackgroundColor(resources.getColor(R.color.transparent, requireContext().theme))
-        (layout as ViewGroup).addView(frameLayout, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        frameLayout.setBackgroundColor(
+            resources.getColor(
+                R.color.transparent,
+                requireContext().theme
+            )
+        )
+        (layout as ViewGroup).addView(
+            frameLayout,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        )
 
         return layout
     }
@@ -108,7 +104,7 @@ class MapFragment : Fragment(), GoogleMap.OnMapClickListener {
 
 
     // Everything below is to give higher scroll/touch precedence to Map Fragment over NestedScrollView container
-    fun setListener(listener: OnTouchListener){
+    fun setListener(listener: OnTouchListener) {
         mListener = listener
     }
 
@@ -116,9 +112,9 @@ class MapFragment : Fragment(), GoogleMap.OnMapClickListener {
         abstract fun onTouch()
     }
 
-    inner class TouchableWrapper(context : Context) : FrameLayout(context) {
+    inner class TouchableWrapper(context: Context) : FrameLayout(context) {
         override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
-            when (ev?.action){
+            when (ev?.action) {
                 MotionEvent.ACTION_DOWN -> mListener.onTouch()
                 MotionEvent.ACTION_UP -> mListener.onTouch()
             }

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/view/TodayFragment.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/view/TodayFragment.kt
@@ -67,6 +67,11 @@ class TodayFragment : Fragment() {
             }
         }
 
+        lifecycleScope.launch {
+            viewModel.pointForecastText.collect {
+                binding.pointForecastLatLong = it
+            }
+        }
 
         viewModel.pointForecastLatLong.observe(viewLifecycleOwner) { newLatLong ->
             binding.tvPointForecastLatLong.text = newLatLong

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/viewmodel/SearchActivityViewModel.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/viewmodel/SearchActivityViewModel.kt
@@ -127,7 +127,13 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
     private fun getGridpointData(forecastArea: ForecastAreaV2?){
         forecastArea?.let { forecastArea ->
             viewModelScope.launch {
-                gridpointData.value = repository.getGridpointData(forecastArea)
+                repository.getGridpointData(forecastArea).collect { gridPointDataStateData ->
+                    when(gridPointDataStateData){
+                        is StateData.Ready -> { }
+                        is StateData.Error -> { }
+                        is StateData.Loading -> { }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/viewmodel/SearchActivityViewModel.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/viewmodel/SearchActivityViewModel.kt
@@ -7,14 +7,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.mattjamesdev.weatherdotgov.data.model.Period
 import com.mattjamesdev.weatherdotgov.data.model.alerts.AlertsResponse
-import com.mattjamesdev.weatherdotgov.data.model.gridpoint.GridpointResponse
 import com.mattjamesdev.weatherdotgov.data.model.hourly.HourlyForecastResponse
 import com.mattjamesdev.weatherdotgov.data.model.sevenday.SevenDayForecastResponse
 import com.mattjamesdev.weatherdotgov.domain.StateData
-import com.mattjamesdev.weatherdotgov.domain.model.CityState
-import com.mattjamesdev.weatherdotgov.domain.model.DayForecast
-import com.mattjamesdev.weatherdotgov.domain.model.ForecastAreaV2
-import com.mattjamesdev.weatherdotgov.domain.model.LatLong
+import com.mattjamesdev.weatherdotgov.domain.model.*
 import com.mattjamesdev.weatherdotgov.repository.SearchActivityRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
@@ -40,12 +36,13 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
     private val TAG = "SearchActivityVM"
     private val repository = SearchActivityRepository()
     val isLoading: MutableLiveData<Boolean> = MutableLiveData(false)
-    val gridpointData: MutableLiveData<GridpointResponse> = MutableLiveData()
+    val gridpointData: MutableLiveData<GridpointData> = MutableLiveData()
     val dailyForecastData: MutableLiveData<MutableList<DayForecast>> = MutableLiveData()
     val hourlyForecastData: MutableLiveData<HourlyForecastResponse> = MutableLiveData()
     val sevenDayForecastData: MutableLiveData<SevenDayForecastResponse> = MutableLiveData()
     val alertData: MutableLiveData<AlertsResponse> = MutableLiveData()
-//    val errorMessage: MutableLiveData<String> = MutableLiveData()
+
+    //    val errorMessage: MutableLiveData<String> = MutableLiveData()
 //    val cityState: MutableLiveData<String> = MutableLiveData()
     val pointForecastLatLong: MutableLiveData<String> = MutableLiveData()
     var mLatitude: Double = 0.0
@@ -53,8 +50,9 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
 
     init {
         viewModelScope.launch {
-            hourlyForecastResponse.combine(sevenDayForecastResponse){ hourlyForecastResponse, sevenDayForecastResponse ->
-                dailyForecastData.value = combineLatestData(hourlyForecastResponse, sevenDayForecastResponse)
+            hourlyForecastResponse.combine(sevenDayForecastResponse) { hourlyForecastResponse, sevenDayForecastResponse ->
+                dailyForecastData.value =
+                    combineLatestData(hourlyForecastResponse, sevenDayForecastResponse)
             }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
         }
     }
@@ -65,25 +63,26 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
         _location.value = latLong
     }
 
-    fun fetchForecastAreaV2(latLong: LatLong){
+    fun fetchForecastAreaV2(latLong: LatLong) {
         isLoading.value = true
         viewModelScope.launch {
-            repository.getForecastAreaV2(latLong.lat, latLong.long).collect { forecastAreaStateData ->
-                if (forecastAreaStateData.state == StateData.State.Ready){
-                    forecastAreaStateData.data?.let {
-                        _cityState.value = CityState(
-                            city = it.city,
-                            state = it.state,
-                        )
+            repository.getForecastAreaV2(latLong.lat, latLong.long)
+                .collect { forecastAreaStateData ->
+                    if (forecastAreaStateData.state == StateData.State.Ready) {
+                        forecastAreaStateData.data?.let {
+                            _cityState.value = CityState(
+                                city = it.city,
+                                state = it.state,
+                            )
+                        }
                     }
+                    getForecastDataV2(forecastAreaStateData)
                 }
-                getForecastDataV2(forecastAreaStateData)
-            }
         }
     }
 
-    private fun getForecastDataV2(forecastAreaStateData: StateData<ForecastAreaV2?>){
-        when(forecastAreaStateData){
+    private fun getForecastDataV2(forecastAreaStateData: StateData<ForecastAreaV2?>) {
+        when (forecastAreaStateData) {
             is StateData.Ready -> {
                 val forecastArea = forecastAreaStateData.data
                 getGridpointData(forecastArea)
@@ -103,52 +102,62 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
         }
     }
 
-    private fun getDailyForecastData(forecastArea: ForecastAreaV2?){
+    private fun getDailyForecastData(forecastArea: ForecastAreaV2?) {
         forecastArea?.let { forecastArea ->
             viewModelScope.launch {
-                repository.getDailyForecastDataV2(forecastArea).flowOn(Dispatchers.IO).collectLatest { dailyForecastDataResponse ->
+                repository.getDailyForecastDataV2(forecastArea).flowOn(Dispatchers.IO)
+                    .collectLatest { dailyForecastDataResponse ->
 
-                }
+                    }
 
             }
         }
     }
 
-    private fun getSevenDayData(forecastArea: ForecastAreaV2?){
+    private fun getSevenDayData(forecastArea: ForecastAreaV2?) {
         forecastArea?.let { forecastArea ->
             viewModelScope.launch {
-                repository.getSevenDayForecastDataV2(forecastArea).flowOn(Dispatchers.IO).collect{
+                repository.getSevenDayForecastDataV2(forecastArea).flowOn(Dispatchers.IO).collect {
                     _sevenDayForecastResponse.value = it
                 }
             }
         }
     }
 
-    private fun getGridpointData(forecastArea: ForecastAreaV2?){
+    private fun getGridpointData(forecastArea: ForecastAreaV2?) {
         forecastArea?.let { forecastArea ->
             viewModelScope.launch {
-                repository.getGridpointData(forecastArea).collect { gridPointDataStateData ->
-                    when(gridPointDataStateData){
-                        is StateData.Ready -> { }
-                        is StateData.Error -> { }
-                        is StateData.Loading -> { }
+                repository.getGridpointData(forecastArea).flowOn(Dispatchers.IO)
+                    .collect { gridPointDataStateData ->
+                        when (gridPointDataStateData) {
+                            is StateData.Ready -> {
+                                gridPointDataStateData.data?.let {
+                                    gridpointData.value = it
+                                }
+                                isLoading.value = false
+                            }
+                            is StateData.Error -> {
+                                showError(gridPointDataStateData.message)
+                                isLoading.value = false
+                            }
+                            is StateData.Loading -> { isLoading.value = true }
+                        }
                     }
-                }
             }
         }
     }
 
-    private fun hourlyForecastData(forecastArea: ForecastAreaV2?){
+    private fun hourlyForecastData(forecastArea: ForecastAreaV2?) {
         forecastArea?.let { forecastArea ->
             viewModelScope.launch {
-                repository.getHourlyForecastDataV2(forecastArea).flowOn(Dispatchers.IO).collect{
+                repository.getHourlyForecastDataV2(forecastArea).flowOn(Dispatchers.IO).collect {
                     _hourlyForecastResponse.value = it
                 }
             }
         }
     }
 
-    private fun alertData(forecastArea: ForecastAreaV2?){
+    private fun alertData(forecastArea: ForecastAreaV2?) {
         forecastArea?.let { forecastArea ->
             viewModelScope.launch {
                 alertData.value = repository.getAlertData(forecastArea)
@@ -156,7 +165,7 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
         }
     }
 
-    private fun showError(message: String){
+    private fun showError(message: String) {
         viewModelScope.launch {
             _errorMessage.value = message
         }
@@ -218,7 +227,10 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
 //    }
 
     // parses the hourly and seven day forecast data into MutableList<DayForecast>
-    private fun combineLatestData(hourlyForecastResponse: HourlyForecastResponse, sevenDayForecastResponse: SevenDayForecastResponse): MutableList<DayForecast> {
+    private fun combineLatestData(
+        hourlyForecastResponse: HourlyForecastResponse,
+        sevenDayForecastResponse: SevenDayForecastResponse
+    ): MutableList<DayForecast> {
         Log.d(TAG, "Combining hourly and daily forecast data...")
 
         // parse hourly data into DayForecast objects and add to dailyData
@@ -226,11 +238,11 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
         var sevenDayPeriods: List<Period?>? = sevenDayForecastResponse.properties?.periods
 
         // initialize list of empty dayForecasts
-        val dayForecastList = MutableList(7){index -> DayForecast() }
+        val dayForecastList = MutableList(7) { index -> DayForecast() }
 
         // initialize each DayForecast
         if (hourlyPeriods != null && sevenDayPeriods != null) {
-            for(dayForecast in dayForecastList) {
+            for (dayForecast in dayForecastList) {
 
                 // initialize date
                 val date = hourlyPeriods?.get(0)?.startTime?.substring(0..9)
@@ -240,7 +252,7 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
 
                 // iterate through hourly data and populate new list of hourly periods with same date
                 val dayHourlyPeriodList = mutableListOf<Period>()
-                for(j in 0 until (hourlyPeriods?.size?.minus(1) ?: 0)){
+                for (j in 0 until (hourlyPeriods?.size?.minus(1) ?: 0)) {
                     /**
                      * if DayForecast.date is the same as current period date:
                      *      add to list of periods
@@ -249,10 +261,11 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
                      *      slice list from j -> end of list
                      */
 
-                    if(dayForecast.date == hourlyPeriods?.get(j)?.startTime?.substring(0,10)){
+                    if (dayForecast.date == hourlyPeriods?.get(j)?.startTime?.substring(0, 10)) {
                         hourlyPeriods?.get(j)?.let { dayHourlyPeriodList.add(it) }
                     } else {
-                        hourlyPeriods = hourlyPeriods?.slice(j until hourlyPeriods.size) as MutableList<Period?>?
+                        hourlyPeriods =
+                            hourlyPeriods?.slice(j until hourlyPeriods.size) as MutableList<Period?>?
                         break
                     }
                 }
@@ -273,7 +286,7 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
                  *      slice sevenDayList from 1 -> end of list
                  */
 
-                if(sevenDayPeriods?.get(0)?.isDaytime == true){
+                if (sevenDayPeriods?.get(0)?.isDaytime == true) {
                     dayForecast.high = sevenDayPeriods[0]
                     dayForecast.low = sevenDayPeriods[1]
                     try {

--- a/app/src/main/java/com/mattjamesdev/weatherdotgov/viewmodel/SearchActivityViewModel.kt
+++ b/app/src/main/java/com/mattjamesdev/weatherdotgov/viewmodel/SearchActivityViewModel.kt
@@ -32,6 +32,9 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
     private val _cityState = MutableStateFlow(CityState.NULL)
     val cityState = _cityState.asStateFlow()
 
+    private val _pointForecastText = MutableStateFlow("")
+    val pointForecastText = _pointForecastText.asStateFlow()
+
     // legacy vals/vars
     private val TAG = "SearchActivityVM"
     private val repository = SearchActivityRepository()
@@ -61,6 +64,7 @@ class SearchActivityViewModel(application: Application) : AndroidViewModel(appli
     fun setLocation(latLong: LatLong) {
         Log.d(TAG, "New location set: lat=${latLong.lat}, long=${latLong.long}")
         _location.value = latLong
+        _pointForecastText.value = latLong.toPointForecast()
     }
 
     fun fetchForecastAreaV2(latLong: LatLong) {

--- a/app/src/main/res/layout/fragment_today.xml
+++ b/app/src/main/res/layout/fragment_today.xml
@@ -16,6 +16,9 @@
         <variable
             name="cityState"
             type="com.mattjamesdev.weatherdotgov.domain.model.CityState" />
+        <variable
+            name="pointForecastLatLong"
+            type="String" />
     </data>
 
     <RelativeLayout
@@ -303,6 +306,7 @@
                                 android:layout_below="@id/tvPointForecastCityState"
                                 android:layout_centerHorizontal="true"
                                 android:textAlignment="center"
+                                android:text="@{pointForecastLatLong}"
                                 />
 
                         </RelativeLayout>


### PR DESCRIPTION
The shaded polygon that depicts the precise forecast area was not displaying on the forecast area map. This fix includes:
- moving the `getGripoints()` API call to use Flow and `safeApiCall{ }`
- improves the conversion of data model to domain model with addition of `GridpointData` class
- adds `LatLong` to `LatLng` and vice-versa conversions through extension functions